### PR TITLE
Add config for overheating effects

### DIFF
--- a/src/main/java/com/Da_Technomancer/crossroads/CommonProxy.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/CommonProxy.java
@@ -15,6 +15,7 @@ import com.Da_Technomancer.crossroads.tileentities.ModTileEntity;
 import com.Da_Technomancer.crossroads.world.ModWorldGen;
 
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.config.Property;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
@@ -26,6 +27,7 @@ public class CommonProxy{
 	protected void preInit(FMLPreInitializationEvent e){
 		Capabilities.register();
 		ModConfig.init(e);
+		ModConfig.additionalConfigs();
 		OreSetUp.init();
 		ModBlocks.init();
 		ModItems.init();

--- a/src/main/java/com/Da_Technomancer/crossroads/ModConfig.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/ModConfig.java
@@ -1,11 +1,15 @@
 package com.Da_Technomancer.crossroads;
 
 import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.common.config.Property;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 
 public final class ModConfig{
 
 	public static Configuration config;
+	
+	public static Property overheatEffects;
+
 
 	protected static void init(FMLPreInitializationEvent e){
 
@@ -21,5 +25,14 @@ public final class ModConfig{
 		 * 
 		 * in order to read the config file, call property.readFoo();
 		 */
+	}
+	
+	
+	protected static void additionalConfigs(){
+		
+		overheatEffects = ModConfig.config.get
+				("heat cables", "Enable all heat cable overheating effects.(default true)", true,
+				("True enables all effects (obsidian, sponge, villager, explosion,etc) on overheat, while "
+						+ "false only enables the fire effect"));
 	}
 }

--- a/src/main/java/com/Da_Technomancer/crossroads/tileentities/heat/HeatCableTileEntity.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/tileentities/heat/HeatCableTileEntity.java
@@ -10,6 +10,7 @@ import com.Da_Technomancer.crossroads.API.enums.HeatInsulators;
 import com.Da_Technomancer.crossroads.API.heat.IHeatHandler;
 
 import net.minecraft.entity.effect.EntityLightningBolt;
+import net.minecraft.init.Blocks;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
@@ -60,9 +61,8 @@ public class HeatCableTileEntity extends TileEntity implements ITickable{
 
 		if(temp > insulator.getLimit()){
 			if(ModConfig.overheatEffects.getBoolean() == false){
-				worldObj.setBlockToAir(pos);
-				worldObj.spawnEntityInWorld(new EntityLightningBolt(worldObj, pos.getX(), pos.getY(), pos.getZ(), false));
-			}else{
+				worldObj.setBlockState(pos, Blocks.FIRE.getDefaultState(), 11);
+				}else{
 				insulator.getEffect().onOverheat(worldObj, pos);
 			}
 		}

--- a/src/main/java/com/Da_Technomancer/crossroads/tileentities/heat/HeatCableTileEntity.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/tileentities/heat/HeatCableTileEntity.java
@@ -2,12 +2,14 @@ package com.Da_Technomancer.crossroads.tileentities.heat;
 
 import javax.annotation.Nullable;
 
+import com.Da_Technomancer.crossroads.ModConfig;
 import com.Da_Technomancer.crossroads.API.Capabilities;
 import com.Da_Technomancer.crossroads.API.EnergyConverters;
 import com.Da_Technomancer.crossroads.API.enums.HeatConductors;
 import com.Da_Technomancer.crossroads.API.enums.HeatInsulators;
 import com.Da_Technomancer.crossroads.API.heat.IHeatHandler;
 
+import net.minecraft.entity.effect.EntityLightningBolt;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
@@ -57,7 +59,12 @@ public class HeatCableTileEntity extends TileEntity implements ITickable{
 		}
 
 		if(temp > insulator.getLimit()){
-			insulator.getEffect().onOverheat(worldObj, pos);
+			if(ModConfig.overheatEffects.getBoolean() == false){
+				worldObj.setBlockToAir(pos);
+				worldObj.spawnEntityInWorld(new EntityLightningBolt(worldObj, pos.getX(), pos.getY(), pos.getZ(), false));
+			}else{
+				insulator.getEffect().onOverheat(worldObj, pos);
+			}
 		}
 	}
 

--- a/src/main/java/com/Da_Technomancer/crossroads/tileentities/heat/RedstoneHeatCableTileEntity.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/tileentities/heat/RedstoneHeatCableTileEntity.java
@@ -12,6 +12,7 @@ import com.Da_Technomancer.crossroads.API.heat.IHeatHandler;
 
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.effect.EntityLightningBolt;
+import net.minecraft.init.Blocks;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
@@ -69,9 +70,8 @@ public class RedstoneHeatCableTileEntity extends TileEntity implements ITickable
 
 		if(temp > insulator.getLimit()){
 			if(ModConfig.overheatEffects.getBoolean() == false){
-				worldObj.setBlockToAir(pos);
-				worldObj.spawnEntityInWorld(new EntityLightningBolt(worldObj, pos.getX(), pos.getY(), pos.getZ(), false));
-			}else{
+                worldObj.setBlockState(pos, Blocks.FIRE.getDefaultState(), 11);
+                }else{
 				insulator.getEffect().onOverheat(worldObj, pos);
 			}
 		}

--- a/src/main/java/com/Da_Technomancer/crossroads/tileentities/heat/RedstoneHeatCableTileEntity.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/tileentities/heat/RedstoneHeatCableTileEntity.java
@@ -2,6 +2,7 @@ package com.Da_Technomancer.crossroads.tileentities.heat;
 
 import javax.annotation.Nullable;
 
+import com.Da_Technomancer.crossroads.ModConfig;
 import com.Da_Technomancer.crossroads.API.Capabilities;
 import com.Da_Technomancer.crossroads.API.EnergyConverters;
 import com.Da_Technomancer.crossroads.API.Properties;
@@ -10,6 +11,7 @@ import com.Da_Technomancer.crossroads.API.enums.HeatInsulators;
 import com.Da_Technomancer.crossroads.API.heat.IHeatHandler;
 
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.effect.EntityLightningBolt;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
@@ -66,7 +68,12 @@ public class RedstoneHeatCableTileEntity extends TileEntity implements ITickable
 		}
 
 		if(temp > insulator.getLimit()){
-			insulator.getEffect().onOverheat(worldObj, pos);
+			if(ModConfig.overheatEffects.getBoolean() == false){
+				worldObj.setBlockToAir(pos);
+				worldObj.spawnEntityInWorld(new EntityLightningBolt(worldObj, pos.getX(), pos.getY(), pos.getZ(), false));
+			}else{
+				insulator.getEffect().onOverheat(worldObj, pos);
+			}
 		}
 	}
 


### PR DESCRIPTION
I am currently the lead developer for the official All The Mods "expert mode" pack, and i'd love to include crossroads as part of the early progression, but the overheating effects are a deal breaker, especially the possibility of obsidian spawning from overheating dirt cables. I have added a very simple config option to disable most of the special overheating effects, and only have a more "conventional" overheating effect where the cable disappears and starts a fire.