### PR TITLE
Improve GatewayAddress conflict resolution

### DIFF
--- a/src/main/java/com/Da_Technomancer/crossroads/API/technomancy/GatewaySavedData.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/API/technomancy/GatewaySavedData.java
@@ -56,11 +56,11 @@ public class GatewaySavedData extends WorldSavedData{
 		GatewayAddress gateAdd;
 		Random rand = new Random(pos.asLong());//We use the position as a seed, so that if a controller is broken and replaced/reformed at the same spot, it will have the same address unless it is already taken
 
-        // set up the initial gateway address. Will be used if there are no collisions
-        int[] initial = new int[4];
+		// set up the initial gateway address. Will be used if there are no collisions
+		int[] initial = new int[4];
 		for(int i = 0; i < 4; i++){
-		    initial[i] = rand.nextInt(8);
-        }
+			initial[i] = rand.nextInt(8);
+		}
 
 		// number of attempts made to pick a new address
 		int attempts = 0;
@@ -69,21 +69,21 @@ public class GatewaySavedData extends WorldSavedData{
 		int[] offsetComponents = new int[4];
 
 		// Loop until the address is not already taken. If it is, use an offset of progressively larger
-        // squares and try again.
-        do{
-            // Gateway address space is 2^12; split the offset up into groups of 3 bits
-            // representing offset for each part of the address
-            offsetComponents[0] = (attempts & 0xe00) >> 9;
-            offsetComponents[1] = (attempts & 0x1c0) >> 6;
-            offsetComponents[2] = (attempts & 0x38) >> 3;
-            offsetComponents[3] = (attempts & 0x7);
+		// squares and try again.
+		do{
+			// Gateway address space is 2^12; split the offset up into groups of 3 bits
+			// representing offset for each part of the address
+			offsetComponents[0] = (attempts & 0xe00) >> 9;
+			offsetComponents[1] = (attempts & 0x1c0) >> 6;
+			offsetComponents[2] = (attempts & 0x38) >> 3;
+			offsetComponents[3] = (attempts & 0x7);
 			for(int i = 0; i < 4; i++){
 				address[i] = GatewayAddress.getLegalEntry(initial[i] + offsetComponents[i]);
 			}
 			gateAdd = new GatewayAddress(address);
-            attempts += 1;
-        }while(data.addressBook.containsKey(gateAdd) || gateAdd.equals(reserved));//Generate a new address every time the generated address is already in use
-		
+			attempts += 1;
+		}while(data.addressBook.containsKey(gateAdd) || gateAdd.equals(reserved));//Generate a new address every time the generated address is already in use
+
 		//Register this new address in the addressBook
 		data.addressBook.put(gateAdd, new GatewayAddress.Location(pos, w));
 		data.setDirty();

--- a/src/main/java/com/Da_Technomancer/crossroads/API/technomancy/GatewaySavedData.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/API/technomancy/GatewaySavedData.java
@@ -71,14 +71,12 @@ public class GatewaySavedData extends WorldSavedData{
 		// Loop until the address is not already taken. If it is, use an offset of progressively larger
         // squares and try again.
         do{
-            quadraticOffset = attempts * attempts;
-
             // Gateway address space is 2^12; split the offset up into groups of 3 bits
             // representing offset for each part of the address
-            offsetComponents[0] = (quadraticOffset & 0xe00) >> 9;
-            offsetComponents[1] = (quadraticOffset & 0x1c0) >> 6;
-            offsetComponents[2] = (quadraticOffset & 0x38) >> 3;
-            offsetComponents[3] = (quadraticOffset & 0x7);
+            offsetComponents[0] = (attempts & 0xe00) >> 9;
+            offsetComponents[1] = (attempts & 0x1c0) >> 6;
+            offsetComponents[2] = (attempts & 0x38) >> 3;
+            offsetComponents[3] = (attempts & 0x7);
 			for(int i = 0; i < 4; i++){
 				address[i] = GatewayAddress.getLegalEntry(initial[i] + offsetComponents[i]);
 			}

--- a/src/main/java/com/Da_Technomancer/crossroads/API/technomancy/GatewaySavedData.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/API/technomancy/GatewaySavedData.java
@@ -73,8 +73,8 @@ public class GatewaySavedData extends WorldSavedData{
         do{
             quadraticOffset = attempts * attempts;
 
-            // Gateway address space is 2^12 bits; split the offset up into groups of 3 bits
-            // representing offset for each coordinate
+            // Gateway address space is 2^12; split the offset up into groups of 3 bits
+            // representing offset for each part of the address
             offsetComponents[0] = (quadraticOffset & 0xe00) >> 9;
             offsetComponents[1] = (quadraticOffset & 0x1c0) >> 6;
             offsetComponents[2] = (quadraticOffset & 0x38) >> 3;

--- a/src/main/java/com/Da_Technomancer/crossroads/API/technomancy/GatewaySavedData.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/API/technomancy/GatewaySavedData.java
@@ -51,17 +51,40 @@ public class GatewaySavedData extends WorldSavedData{
 		}
 
 		//Generate a unique new address
-		//TODO: Optimize this for a large number of taken addresses
 		EnumBeamAlignments[] address = new EnumBeamAlignments[4];
 		GatewayAddress reserved = getReservedAddress(w);
 		GatewayAddress gateAdd;
 		Random rand = new Random(pos.asLong());//We use the position as a seed, so that if a controller is broken and replaced/reformed at the same spot, it will have the same address unless it is already taken
-		do{
+
+        // set up the initial gateway address. Will be used if there are no collisions
+        int[] initial = new int[4];
+		for(int i = 0; i < 4; i++){
+		    initial[i] = rand.nextInt(8);
+        }
+
+		// number of attempts made to pick a new address
+		int attempts = 0;
+
+		int quadraticOffset;
+		int[] offsetComponents = new int[4];
+
+		// Loop until the address is not already taken. If it is, use an offset of progressively larger
+        // squares and try again.
+        do{
+            quadraticOffset = attempts * attempts;
+
+            // Gateway address space is 2^12 bits; split the offset up into groups of 3 bits
+            // representing offset for each coordinate
+            offsetComponents[0] = (quadraticOffset & 0xe00) >> 9;
+            offsetComponents[1] = (quadraticOffset & 0x1c0) >> 6;
+            offsetComponents[2] = (quadraticOffset & 0x38) >> 3;
+            offsetComponents[3] = (quadraticOffset & 0x7);
 			for(int i = 0; i < 4; i++){
-				address[i] = GatewayAddress.getLegalEntry(rand.nextInt(GatewayAddress.LEGAL_VALS.length));
+				address[i] = GatewayAddress.getLegalEntry(initial[i] + offsetComponents[i]);
 			}
 			gateAdd = new GatewayAddress(address);
-		}while(data.addressBook.containsKey(gateAdd) || gateAdd.equals(reserved));//Generate a new address every time the generated address is already in use
+            attempts += 1;
+        }while(data.addressBook.containsKey(gateAdd) || gateAdd.equals(reserved));//Generate a new address every time the generated address is already in use
 		
 		//Register this new address in the addressBook
 		data.addressBook.put(gateAdd, new GatewayAddress.Location(pos, w));


### PR DESCRIPTION
Resolves #157 

The gateway addressing system is comparable to inserting values into a hash table of fixed size, using open addressing, with a seeded RNG as the hash function. The old system of collision resolution re-rolled until it didn't collide; now it adds progressively larger squares to the initial address until it doesn't collide. 

This substantially reduces chances of colliding on the same address twice for any given insertion, and performs better when the address space begins to fill up.