### PR TITLE
Fixed double speed stamp mill

### DIFF
--- a/src/main/java/com/Da_Technomancer/crossroads/tileentities/rotary/StampMillTileEntity.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/tileentities/rotary/StampMillTileEntity.java
@@ -111,15 +111,6 @@ public class StampMillTileEntity extends InventoryTE{
 				}
 			}
 
-			if(++timer >= TIME_LIMIT || progress >= REQUIRED){
-				timer = 0;
-				if(progress >= REQUIRED){
-					progress = 0;
-					successCraft();
-				}else{
-					failCraft();
-				}
-			}
 			setChanged();
 		}
 	}


### PR DESCRIPTION
This second if clause is not needed for the chance based craft success, and it also increments timer twice causing the mill to process twice as fast and require twice the rotary input.