### PR TITLE
fix hand crank exploit by adding a 4 tick usage cooldown

### DIFF
--- a/src/main/java/com/Da_Technomancer/crossroads/items/CheatWandHeat.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/items/CheatWandHeat.java
@@ -36,6 +36,7 @@ public class CheatWandHeat extends Item{
 			}else{
 				cable.addHeat(RATE);
 			}
+			context.getPlayer().getCooldowns().addCooldown(this, 4);
 			return InteractionResult.SUCCESS;
 		}
 		return InteractionResult.PASS;

--- a/src/main/java/com/Da_Technomancer/crossroads/items/HandCrank.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/items/HandCrank.java
@@ -45,7 +45,7 @@ public class HandCrank extends Item{
 			}
 			signMult *= RotaryUtil.getCCWSign(side);
 			axleOpt.orElseThrow(NullPointerException::new).addEnergy(getRate() * signMult, true);
-            context.getPlayer().getCooldowns().addCooldown(this,4);
+			context.getPlayer().getCooldowns().addCooldown(this, 4);
 			return InteractionResult.SUCCESS;
 		}
 		return InteractionResult.PASS;

--- a/src/main/java/com/Da_Technomancer/crossroads/items/HandCrank.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/items/HandCrank.java
@@ -45,6 +45,7 @@ public class HandCrank extends Item{
 			}
 			signMult *= RotaryUtil.getCCWSign(side);
 			axleOpt.orElseThrow(NullPointerException::new).addEnergy(getRate() * signMult, true);
+            context.getPlayer().getCooldowns().addCooldown(this,4);
 			return InteractionResult.SUCCESS;
 		}
 		return InteractionResult.PASS;


### PR DESCRIPTION
pretty self explanatory. Adds a 4 tick usage cooldown to the item after a valid use with the `player.getCooldowns().addCooldown()` method, which prevents autoclickers from using it faster than the intended 5/s (once every 4 ticks).