### PR TITLE
Fix Edible Blob bugs

### DIFF
--- a/src/main/java/com/Da_Technomancer/crossroads/blocks/fluid/FatCongealerTileEntity.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/blocks/fluid/FatCongealerTileEntity.java
@@ -90,7 +90,7 @@ public class FatCongealerTileEntity extends InventoryTE{
 				sat = (int) Math.min(Math.abs(bottomHandler.getSpeed()) * SAT_PER_SPD, 20);
 			}
 
-			if(hun != 0 || sat != 0){
+			if(hun > 0){
 				int fluidUse = CRConfig.fatPerValue.get() * (hun + sat);
 				if(fluidUse > fluids[0].getAmount()){
 					return;

--- a/src/main/java/com/Da_Technomancer/crossroads/items/EdibleBlob.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/items/EdibleBlob.java
@@ -1,7 +1,6 @@
 package com.Da_Technomancer.crossroads.items;
 
 import com.Da_Technomancer.crossroads.api.MiscUtil;
-
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.LivingEntity;
@@ -32,7 +31,7 @@ public class EdibleBlob extends Item{
 	}
 
 	public static int getHealAmount(ItemStack stack){
-		return stack.hasTag() ? stack.getTag().getInt("food") : 0;
+		return Math.max(stack.hasTag() ? stack.getTag().getInt("food") : 0, 1);
 	}
 
 	/**
@@ -58,16 +57,10 @@ public class EdibleBlob extends Item{
 	@Nullable
 	// build FoodProperties from NBT on-the-fly
 	public FoodProperties getFoodProperties(ItemStack stack, @Nullable LivingEntity entity) {
-		CompoundTag tags = stack.getTag();
-		if (tags != null) {
-			int hun = tags.getInt("food");
-			int sat = tags.getInt("sat");
-			//make sure old 0 food blobs still give saturation (and avoid a div by 0 error)
-			if(hun == 0){hun = 1;}
-			float sat_mod = (float) sat / (float) hun;
-			return new FoodProperties.Builder().nutrition(hun).saturationMod(sat_mod).meat().alwaysEat().build();
-		}
-		return null;
+		int hun = getHealAmount(stack);
+		int sat = getTrueSat(stack);
+		float sat_mod = (float) sat / (float) hun;
+		return new FoodProperties.Builder().nutrition(hun).saturationMod(sat_mod).meat().build();
 	}
 	@Override
 	public boolean isEdible(){

--- a/src/main/java/com/Da_Technomancer/crossroads/items/EdibleBlob.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/items/EdibleBlob.java
@@ -1,24 +1,14 @@
 package com.Da_Technomancer.crossroads.items;
 
 import com.Da_Technomancer.crossroads.api.MiscUtil;
-import net.minecraft.advancements.CriteriaTriggers;
+
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
-import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.sounds.SoundEvents;
-import net.minecraft.sounds.SoundSource;
-import net.minecraft.stats.Stats;
-import net.minecraft.world.InteractionHand;
-import net.minecraft.world.InteractionResult;
-import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.food.FoodData;
 import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
-import net.minecraft.world.item.UseAnim;
 import net.minecraft.world.level.Level;
 
 import javax.annotation.Nullable;
@@ -66,12 +56,16 @@ public class EdibleBlob extends Item{
 
 	@Override
 	@Nullable
+	// build FoodProperties from NBT on-the-fly
 	public FoodProperties getFoodProperties(ItemStack stack, @Nullable LivingEntity entity) {
 		CompoundTag tags = stack.getTag();
 		if (tags != null) {
 			int hun = tags.getInt("food");
 			int sat = tags.getInt("sat");
-			return new FoodProperties.Builder().nutrition(hun).saturationMod(sat).meat().alwaysEat().build();
+			//make sure old 0 food blobs still give saturation (and avoid a div by 0 error)
+			if(hun == 0){hun = 1;}
+			float sat_mod = (float) sat / (float) hun;
+			return new FoodProperties.Builder().nutrition(hun).saturationMod(sat_mod).meat().alwaysEat().build();
 		}
 		return null;
 	}

--- a/src/main/resources/assets/essentials/patchouli_books/manual/en_us/entries/fluid/fat_congealer.json
+++ b/src/main/resources/assets/essentials/patchouli_books/manual/en_us/entries/fluid/fat_congealer.json
@@ -14,7 +14,11 @@
 		},
 		{
 			"type": "patchouli:text",
-			"text": "The hunger value of the <item>edible blobs/$ is equal to 4 times the <thing>$(l:essentials:intro/rotary)speed/$ of the top gear. The saturation value is 4 times the <thing>$(l:essentials:intro/rotary)speed/$ of the bottom gear.$(br2)Each <item>edible blob/$ consumes 100mB of <thing>liquid fat/$ per point of hunger and saturation, and a small amount of <thing>$(l:essentials:intro/rotary)rotary energy/$. A redstone signal will disable the machine.$(br2)"
+			"text": "The hunger value of the <item>edible blobs/$ is equal to 4 times the <thing>$(l:essentials:intro/rotary)speed/$ of the top gear. The saturation value is 4 times the <thing>$(l:essentials:intro/rotary)speed/$ of the bottom gear. Additionally, <item>edible blobs/$ must have a hunger value greater than or equal to 1.$(br2)Each <item>edible blob/$ consumes 100mB of <thing>liquid fat/$ per point of hunger and saturation, and a small amount of <thing>$(l:essentials:intro/rotary)rotary "
+		},
+		{
+			"type": "patchouli:text",
+			"text": "<thing>$(l:essentials:intro/rotary)energy/$. A redstone signal will disable the machine.$(br2)"
 		}
 	]
 }

--- a/src/main/resources/python/docs/src/fluid/fat_congealer.txt
+++ b/src/main/resources/python/docs/src/fluid/fat_congealer.txt
@@ -1,5 +1,5 @@
 Fat Congealer
 crossroads:fat_congealer
 The <item>Fat Congealer/$ uses <thing>liquid fat/$ (from a <item><link:essentials:fluid/fat_collector>fat collector/$) to produce <item>edible blobs/$, which are food with custom stats. The <item>fat congealer/$ has <em>two rotary connections/$ (top and bottom), instead of the usual one. It accepts <thing>liquid fat/$ in the sides, and has an output side where it will eject <item>edible blobs/$.
-The hunger value of the <item>edible blobs/$ is equal to 4 times the <thing><link:essentials:intro/rotary>speed/$ of the top gear. The saturation value is 4 times the <thing><link:essentials:intro/rotary>speed/$ of the bottom gear.
+The hunger value of the <item>edible blobs/$ is equal to 4 times the <thing><link:essentials:intro/rotary>speed/$ of the top gear. The saturation value is 4 times the <thing><link:essentials:intro/rotary>speed/$ of the bottom gear. Additionally, <item>edible blobs/$ must have a hunger value greater than or equal to 1.
 Each <item>edible blob/$ consumes 100mB of <thing>liquid fat/$ per point of hunger and saturation, and a small amount of <thing><link:essentials:intro/rotary>rotary energy/$. A redstone signal will disable the machine.


### PR DESCRIPTION
As noted in #105 , the current Edible Blob implementation is quite buggy since most Vanilla/Forge methods that involve foods work with `FoodProperties`', which are never provided by the Edible Blob code since it uses a custom, NBT-based food system that never touches Vanilla code. My implementation takes advantage of the fact that Forge allows you to override the `getFoodProperties()` method in `IForgeItem` to return a vanilla/mod friendly `FoodProperties` that is built on-the-fly with hunger and saturation values from the `ItemStack` of blobs (as well as an identifier that allows you to feed dogs with them). This along with a simple override of the `isEdible()` method (the default method would always return false since our `FoodProperties` aren't hardcoded into the item) allows for improved mod compatibility, fixes the bugs when feeding dogs  all while simplifying the code drastically (since we can remove all of the custom hunger management code and allow Vanilla to do it for us)

Edit: The code in this PR will throw an NPE if the "food" or "sat" NBT tags are missing, but that can easily be fixed with a couple of null checks, and NBT-less edible blobs are unobtainable without commands anyways.