### PR TITLE
[1.18.2] Update JEI and fix fluid recipes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,10 +92,11 @@ dependencies {
 	minecraft("net.minecraftforge:forge:$mc_version-$fg_version")
 
 	//Compile against APIs
-	compileOnly(fg.deobf("mezz.jei:jei-$jei_mc_version:$jei_version:api"))//JEI
+	compileOnly(fg.deobf("mezz.jei:jei-$jei_mc_version-common-api:$jei_version"))//JEI
+	compileOnly(fg.deobf("mezz.jei:jei-$jei_mc_version-forge-api:$jei_version"))//JEI
 	compileOnly(fg.deobf("top.theillusivec4.curios:curios-forge:$curios_version:api"))//Curios
 	//Run with the full versions
-	runtimeOnly(fg.deobf("mezz.jei:jei-$jei_mc_version:$jei_version"))//JEI
+	runtimeOnly(fg.deobf("mezz.jei:jei-$jei_mc_version-forge:$jei_version"))//JEI
 	runtimeOnly(fg.deobf("top.theillusivec4.curios:curios-forge:$curios_version"))//Curios
 
 	compileOnly(fg.deobf("vazkii.patchouli:Patchouli:$patchouli_version"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ mcp_channel=official
 mcp_version=1.18.2
 essentials_version=1.18.2-2.13.4
 jei_mc_version=1.18.2
-jei_version=9.5.5.174
+jei_version=10.2.1.1005
 patchouli_version=1.18.2-67
 curios_version=1.18.2-5.0.7.0
 # Outdated- currently not being built against

--- a/src/main/java/com/Da_Technomancer/crossroads/integration/JEI/BlastFurnaceCategory.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/integration/JEI/BlastFurnaceCategory.java
@@ -7,6 +7,7 @@ import com.Da_Technomancer.crossroads.crafting.recipes.BlastFurnaceRec;
 import com.Da_Technomancer.crossroads.items.CRItems;
 import com.mojang.blaze3d.vertex.PoseStack;
 import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.forge.ForgeTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.drawable.IDrawableAnimated;
@@ -79,7 +80,7 @@ public class BlastFurnaceCategory implements IRecipeCategory<BlastFurnaceRec>{
 	public void setRecipe(IRecipeLayoutBuilder builder, BlastFurnaceRec recipe, IFocusGroup focuses){
 		builder.addSlot(RecipeIngredientRole.INPUT, 55, 56).addIngredients(recipe.getIngredient());
 		builder.addSlot(RecipeIngredientRole.OUTPUT, 131, 56).addItemStack(new ItemStack(CRItems.slag, recipe.getSlag()));
-		builder.addSlot(RecipeIngredientRole.OUTPUT, 111, 23).addIngredient(VanillaTypes.FLUID, recipe.getOutput()).setFluidRenderer(1000, true, 16, 64).setOverlay(fluidOverlay, 0, 0);
+		builder.addSlot(RecipeIngredientRole.OUTPUT, 111, 23).addIngredient(ForgeTypes.FLUID_STACK, recipe.getOutput()).setFluidRenderer(1000L, true, 16, 64).setOverlay(fluidOverlay, 0, 0);
 	}
 
 	@Override

--- a/src/main/java/com/Da_Technomancer/crossroads/integration/JEI/CentrifugeCategory.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/integration/JEI/CentrifugeCategory.java
@@ -5,6 +5,7 @@ import com.Da_Technomancer.crossroads.blocks.CRBlocks;
 import com.Da_Technomancer.crossroads.crafting.recipes.CentrifugeRec;
 import com.mojang.blaze3d.vertex.PoseStack;
 import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.forge.ForgeTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.drawable.IDrawableAnimated;
@@ -72,8 +73,8 @@ public class CentrifugeCategory implements IRecipeCategory<CentrifugeRec>{
 
 	@Override
 	public void setRecipe(IRecipeLayoutBuilder builder, CentrifugeRec recipe, IFocusGroup focuses){
-		builder.addSlot(RecipeIngredientRole.INPUT, 51, 31).addIngredient(VanillaTypes.FLUID, recipe.getInput()).setFluidRenderer(4000, true, 16, 32).setOverlay(fluidOverlay, 0, 0);
-		builder.addSlot(RecipeIngredientRole.OUTPUT, 111, 31).addIngredient(VanillaTypes.FLUID, recipe.getFluidOutput()).setFluidRenderer(4000, true, 16, 32).setOverlay(fluidOverlay, 0, 0);
+		builder.addSlot(RecipeIngredientRole.INPUT, 51, 31).addIngredient(ForgeTypes.FLUID_STACK, recipe.getInput()).setFluidRenderer(4000L, true, 16, 32).setOverlay(fluidOverlay, 0, 0);
+		builder.addSlot(RecipeIngredientRole.OUTPUT, 111, 31).addIngredient(ForgeTypes.FLUID_STACK, recipe.getFluidOutput()).setFluidRenderer(4000L, true, 16, 32).setOverlay(fluidOverlay, 0, 0);
 		builder.addSlot(RecipeIngredientRole.OUTPUT, 131, 31).addItemStacks(recipe.getOutputList());
 	}
 

--- a/src/main/java/com/Da_Technomancer/crossroads/integration/JEI/CopshowiumCategory.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/integration/JEI/CopshowiumCategory.java
@@ -7,6 +7,7 @@ import com.Da_Technomancer.crossroads.crafting.recipes.CopshowiumRec;
 import com.Da_Technomancer.crossroads.fluids.CRFluids;
 import com.mojang.blaze3d.vertex.PoseStack;
 import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.forge.ForgeTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.drawable.IDrawableAnimated;
@@ -77,8 +78,8 @@ public class CopshowiumCategory implements IRecipeCategory<CopshowiumRec>{
 	@Override
 	public void setRecipe(IRecipeLayoutBuilder builder, CopshowiumRec recipe, IFocusGroup focuses){
 		int displaySize = 1000;
-		builder.addSlot(RecipeIngredientRole.INPUT, 51, 31).addIngredients(VanillaTypes.FLUID, recipe.getInput().getMatchedFluidStacks(displaySize)).setFluidRenderer(4000, true, 16, 64).setOverlay(fluidOverlay, 0, 0);
-		builder.addSlot(RecipeIngredientRole.OUTPUT, 111, 31).addIngredient(VanillaTypes.FLUID, new FluidStack(CRFluids.moltenCopshowium.still, (int) (displaySize * recipe.getMult()))).setFluidRenderer(4000, true, 16, 64).setOverlay(fluidOverlay, 0, 0);
+		builder.addSlot(RecipeIngredientRole.INPUT, 51, 31).addIngredients(ForgeTypes.FLUID_STACK, recipe.getInput().getMatchedFluidStacks(displaySize)).setFluidRenderer(4000L, true, 16, 64).setOverlay(fluidOverlay, 0, 0);
+		builder.addSlot(RecipeIngredientRole.OUTPUT, 111, 31).addIngredient(ForgeTypes.FLUID_STACK, new FluidStack(CRFluids.moltenCopshowium.still, (int) (displaySize * recipe.getMult()))).setFluidRenderer(4000L, true, 16, 64).setOverlay(fluidOverlay, 0, 0);
 	}
 
 	@Override

--- a/src/main/java/com/Da_Technomancer/crossroads/integration/JEI/FluidCoolingCategory.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/integration/JEI/FluidCoolingCategory.java
@@ -6,6 +6,7 @@ import com.Da_Technomancer.crossroads.blocks.CRBlocks;
 import com.Da_Technomancer.crossroads.crafting.recipes.FluidCoolingRec;
 import com.mojang.blaze3d.vertex.PoseStack;
 import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.forge.ForgeTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.drawable.IDrawableAnimated;
@@ -76,7 +77,7 @@ public class FluidCoolingCategory implements IRecipeCategory<FluidCoolingRec>{
 
 	@Override
 	public void setRecipe(IRecipeLayoutBuilder builder, FluidCoolingRec recipe, IFocusGroup focuses){
-		builder.addSlot(RecipeIngredientRole.INPUT, 51, 31).addIngredients(VanillaTypes.FLUID, recipe.getInput().getMatchedFluidStacks(recipe.getInputQty())).setFluidRenderer(1000, true, 16, 64).setOverlay(fluidOverlay, 0, 0);
+		builder.addSlot(RecipeIngredientRole.INPUT, 51, 31).addIngredients(ForgeTypes.FLUID_STACK, recipe.getInput().getMatchedFluidStacks(recipe.getInputQty())).setFluidRenderer(1000L, true, 16, 64).setOverlay(fluidOverlay, 0, 0);
 		builder.addSlot(RecipeIngredientRole.OUTPUT, 111, 56).addItemStack(recipe.getResultItem());
 	}
 

--- a/src/main/java/com/Da_Technomancer/crossroads/integration/JEI/FormulationVatCategory.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/integration/JEI/FormulationVatCategory.java
@@ -5,6 +5,7 @@ import com.Da_Technomancer.crossroads.blocks.CRBlocks;
 import com.Da_Technomancer.crossroads.crafting.recipes.FormulationVatRec;
 import com.mojang.blaze3d.vertex.PoseStack;
 import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.forge.ForgeTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.drawable.IDrawableAnimated;
@@ -72,9 +73,9 @@ public class FormulationVatCategory implements IRecipeCategory<FormulationVatRec
 
 	@Override
 	public void setRecipe(IRecipeLayoutBuilder builder, FormulationVatRec recipe, IFocusGroup focuses){
-		builder.addSlot(RecipeIngredientRole.INPUT, 31, 31).addIngredients(VanillaTypes.FLUID, recipe.getInput().getMatchedFluidStacks(recipe.getInputQty())).setFluidRenderer(4000, true, 16, 64).setOverlay(fluidOverlay, 0, 0);
+		builder.addSlot(RecipeIngredientRole.INPUT, 31, 31).addIngredients(ForgeTypes.FLUID_STACK, recipe.getInput().getMatchedFluidStacks(recipe.getInputQty())).setFluidRenderer(4000L, true, 16, 64).setOverlay(fluidOverlay, 0, 0);
 		builder.addSlot(RecipeIngredientRole.INPUT, 51, 56).addIngredients(recipe.getIngredient());
-		builder.addSlot(RecipeIngredientRole.OUTPUT, 111, 31).addIngredient(VanillaTypes.FLUID, recipe.getOutput()).setFluidRenderer(4000, true, 16, 64).setOverlay(fluidOverlay, 0, 0);
+		builder.addSlot(RecipeIngredientRole.OUTPUT, 111, 31).addIngredient(ForgeTypes.FLUID_STACK, recipe.getOutput()).setFluidRenderer(4000L, true, 16, 64).setOverlay(fluidOverlay, 0, 0);
 	}
 
 	@Override

--- a/src/main/java/com/Da_Technomancer/crossroads/integration/JEI/HeatingCrucibleCategory.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/integration/JEI/HeatingCrucibleCategory.java
@@ -6,6 +6,7 @@ import com.Da_Technomancer.crossroads.crafting.recipes.CrucibleRec;
 import com.Da_Technomancer.crossroads.tileentities.heat.HeatingCrucibleTileEntity;
 import com.mojang.blaze3d.vertex.PoseStack;
 import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.forge.ForgeTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.drawable.IDrawableAnimated;
@@ -78,7 +79,7 @@ public class HeatingCrucibleCategory implements IRecipeCategory<CrucibleRec>{
 	@Override
 	public void setRecipe(IRecipeLayoutBuilder builder, CrucibleRec recipe, IFocusGroup focuses){
 		builder.addSlot(RecipeIngredientRole.INPUT, 41, 51).addIngredients(recipe.getIngredient());
-		builder.addSlot(RecipeIngredientRole.OUTPUT, 91, 31).addIngredient(VanillaTypes.FLUID, recipe.getOutput()).setFluidRenderer(2000, true, 16, 64).setOverlay(fluidOverlay, 0, 0);
+		builder.addSlot(RecipeIngredientRole.OUTPUT, 91, 31).addIngredient(ForgeTypes.FLUID_STACK, recipe.getOutput()).setFluidRenderer(2000L, true, 16, 64).setOverlay(fluidOverlay, 0, 0);
 	}
 
 	@Override

--- a/src/main/java/com/Da_Technomancer/crossroads/integration/JEI/OreCleanserCategory.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/integration/JEI/OreCleanserCategory.java
@@ -7,6 +7,7 @@ import com.Da_Technomancer.crossroads.fluids.CRFluids;
 import com.Da_Technomancer.crossroads.tileentities.fluid.OreCleanserTileEntity;
 import com.mojang.blaze3d.vertex.PoseStack;
 import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.forge.ForgeTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.drawable.IDrawableAnimated;
@@ -83,8 +84,8 @@ public class OreCleanserCategory implements IRecipeCategory<OreCleanserRec>{
 	@Override
 	public void setRecipe(IRecipeLayoutBuilder builder, OreCleanserRec recipe, IFocusGroup focuses){
 		builder.addSlot(RecipeIngredientRole.INPUT, 55, 51).addIngredients(recipe.getIngredient());
-		builder.addSlot(RecipeIngredientRole.INPUT, 35, 31).addIngredient(VanillaTypes.FLUID, new FluidStack(CRFluids.steam.still, OreCleanserTileEntity.WATER_USE)).setFluidRenderer(1000, true, 16, 64).setOverlay(fluidOverlay, 0, 0);
+		builder.addSlot(RecipeIngredientRole.INPUT, 35, 31).addIngredient(ForgeTypes.FLUID_STACK, new FluidStack(CRFluids.steam.still, OreCleanserTileEntity.WATER_USE)).setFluidRenderer(1000L, true, 16, 64).setOverlay(fluidOverlay, 0, 0);
 		builder.addSlot(RecipeIngredientRole.OUTPUT, 111, 51).addItemStack(recipe.getResultItem());
-		builder.addSlot(RecipeIngredientRole.OUTPUT, 131, 31).addIngredient(VanillaTypes.FLUID, new FluidStack(CRFluids.dirtyWater.still, OreCleanserTileEntity.WATER_USE)).setFluidRenderer(1000, true, 16, 64).setOverlay(fluidOverlay, 0, 0);
+		builder.addSlot(RecipeIngredientRole.OUTPUT, 131, 31).addIngredient(ForgeTypes.FLUID_STACK, new FluidStack(CRFluids.dirtyWater.still, OreCleanserTileEntity.WATER_USE)).setFluidRenderer(1000L, true, 16, 64).setOverlay(fluidOverlay, 0, 0);
 	}
 }


### PR DESCRIPTION
Fixes #258

This updates the 1.18 branch to the latest available version of JEI and fixes the issue with fluid recipes. I fixed one deprecation that happened to be on the same line as the fluid fix, but there are others that I didn't touch since I don't really know what I'm doing and didn't want to mess anything up.

I verified the change in an updated version of the Infinity Foundation modpack.

<img width="530" alt="Screenshot 2023-10-16 at 1 19 52 PM" src="https://github.com/Crossroads-Development/Crossroads/assets/17329408/33425ee1-cc15-4d0a-9025-1c1de43041d5">
