### PR TITLE
fix stasis chamber/freezer not reverting spoilage time when loaded on servers

### DIFF
--- a/src/main/java/com/Da_Technomancer/crossroads/blocks/witchcraft/ColdStorageTileEntity.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/blocks/witchcraft/ColdStorageTileEntity.java
@@ -90,10 +90,10 @@ public class ColdStorageTileEntity extends InventoryTE{
 			//When we reload, we do a single large freeze operation to account for time spent unloaded, plus a small extra as a buffer
 			long gameTime = level.getGameTime();
 
-			if(gameTime > lastTick){
+			if(gameTime > lastTick && lastTick != 0){
 				for(ItemStack stack : inventory){
 					if(stack.getItem() instanceof IPerishable perishable){
-						perishable.freeze(stack, level, temp, gameTime - lastTick + 1);
+						perishable.freeze(stack, level, temp, gameTime - lastTick + 5);
 					}
 				}
 			}

--- a/src/main/java/com/Da_Technomancer/crossroads/blocks/witchcraft/ColdStorageTileEntity.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/blocks/witchcraft/ColdStorageTileEntity.java
@@ -79,23 +79,26 @@ public class ColdStorageTileEntity extends InventoryTE{
 		lastTick = gameTime;
 		setChanged();
 	}
-
+	//Called whenever a BlockEntity is loaded
 	@Override
-	public void onLoad(){
-		super.onLoad();
-		//While this block is unloaded, the gametime has still been advancing,
-		//so the stored items have decayed without this block countering that
-		//When we reload, we do a single large freeze operation to account for time spent unloaded, plus a small extra as a buffer
-		long gameTime = level.getGameTime();
-		if(gameTime > lastTick){
-			for(ItemStack stack : inventory){
-				if(stack.getItem() instanceof IPerishable){
-					((IPerishable) stack.getItem()).freeze(stack, level, temp, gameTime - lastTick + 1);
+	public void clearRemoved(){
+		super.clearRemoved();
+		//Server side only
+		if(!level.isClientSide()){
+			//While this block is unloaded, the gametime has still been advancing,
+			//so the stored items have decayed without this block countering that
+			//When we reload, we do a single large freeze operation to account for time spent unloaded, plus a small extra as a buffer
+			long gameTime = level.getGameTime();
+
+			if(gameTime > lastTick){
+				for(ItemStack stack : inventory){
+					if(stack.getItem() instanceof IPerishable perishable){
+						perishable.freeze(stack, level, temp, gameTime - lastTick + 1);
+					}
 				}
 			}
+			lastTick = gameTime;
 		}
-		lastTick = gameTime;
-//		setChanged(); Note to self: Calling setChanged() in onLoad() freezes the loading process; bad
 	}
 
 	@Override

--- a/src/main/java/com/Da_Technomancer/crossroads/blocks/witchcraft/StasisStorageTileEntity.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/blocks/witchcraft/StasisStorageTileEntity.java
@@ -72,10 +72,10 @@ public class StasisStorageTileEntity extends InventoryTE{
 			//When we reload, we do a single large freeze operation to account for time spent unloaded, plus a small extra as a buffer
 			long gameTime = level.getGameTime();
 
-			if(gameTime > lastTick){
+			if(gameTime > lastTick && lastTick != 0){
 				for(ItemStack stack : inventory){
 					if(stack.getItem() instanceof IPerishable){
-						IPerishable.setSpoilTime(stack, IPerishable.getAndInitSpoilTime(stack, level) + gameTime - lastTick + 1, 0);
+						IPerishable.setSpoilTime(stack, IPerishable.getAndInitSpoilTime(stack, level) + gameTime - lastTick + 5, 0);
 					}
 				}
 			}

--- a/src/main/java/com/Da_Technomancer/crossroads/blocks/witchcraft/StasisStorageTileEntity.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/blocks/witchcraft/StasisStorageTileEntity.java
@@ -61,22 +61,26 @@ public class StasisStorageTileEntity extends InventoryTE{
 		setChanged();
 	}
 
+	//Called whenever a TileEntity is loaded
 	@Override
-	public void onLoad(){
-		super.onLoad();
-		//While this block is unloaded, the gametime has still been advancing,
-		//so the stored items have decayed without this block countering that
-		//When we reload, we do a single large freeze operation to account for time spent unloaded, plus a small extra as a buffer
-		long gameTime = level.getGameTime();
-		if(gameTime > lastTick){
-			for(ItemStack stack : inventory){
-				if(stack.getItem() instanceof IPerishable perishable){
-					IPerishable.setSpoilTime(stack, IPerishable.getAndInitSpoilTime(stack, level) + gameTime - lastTick + 1, 0);
+	public void clearRemoved(){
+		super.clearRemoved();
+		//Server side only
+		if(!level.isClientSide()){
+			//While this block is unloaded, the gametime has still been advancing,
+			//so the stored items have decayed without this block countering that
+			//When we reload, we do a single large freeze operation to account for time spent unloaded, plus a small extra as a buffer
+			long gameTime = level.getGameTime();
+
+			if(gameTime > lastTick){
+				for(ItemStack stack : inventory){
+					if(stack.getItem() instanceof IPerishable){
+						IPerishable.setSpoilTime(stack, IPerishable.getAndInitSpoilTime(stack, level) + gameTime - lastTick + 1, 0);
+					}
 				}
 			}
+			lastTick = gameTime;
 		}
-		lastTick = gameTime;
-//		setChanged(); Note to self: Calling setChanged() in onLoad() freezes the loading process; bad
 	}
 
 	@Override


### PR DESCRIPTION
moves the code from `onLoad` into `clearRemoved`, which actually gets called on the server side (along with a check to ensure it's not run on the client). Should fix #301
Needs more thorough testing