### PR TITLE
Fix a NPE with Sedation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -50,8 +50,8 @@ mod_issue_tracker=https://github.com/Crossroads-Development/Crossroads/issues
 
 ### Dependencies
 # Can either depend on a release version of Essentials (published to Curse) or a WIP dev version (needs to be in libs folder)
-essentials_dev_variant=true
-essentials_file_id=5549158
+essentials_dev_variant=false
+essentials_file_id=7647067
 essentials_version=2.17.2
 jei_version=19.25.1.332
 patchouli_version=1.21.1-92

--- a/src/main/java/com/Da_Technomancer/crossroads/entity/mob_effects/Sedation.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/entity/mob_effects/Sedation.java
@@ -95,7 +95,7 @@ public class Sedation extends MobEffect{
 
 	public static void checkForEffectEnd(LivingEntity entity, MobEffectInstance endedEffect){
 		//Called by event handlers
-		if(endedEffect.is(CRPotions.SEDATION_EFFECT)){
+		if(endedEffect != null && endedEffect.is(CRPotions.SEDATION_EFFECT)){
 			if(canSedationApplyFully(entity) && entity instanceof Mob mob){
 				mob.setNoAi(false);
 				mob.getPersistentData().putBoolean(SEDATION_KEY, false);


### PR DESCRIPTION
This fixes a NPE I noticed with Sedation that can show up when other mods are present; `endedEffect` [here](https://github.com/Crossroads-Development/Crossroads/blob/4c3526cefe6c0b4c82b88d63df0bcf4a2b87fc20/src/main/java/com/Da_Technomancer/crossroads/entity/mob_effects/Sedation.java#L98) can in fact be null.