### PR TITLE
Fix perishable items still perishing when in non-ticking spawn chunks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ crash-reports/
 /classes/
 /net/
 /testing/
+/.vscode/
+/.eclipse/
 
 # File Extensions
 *.psd

--- a/src/main/java/com/Da_Technomancer/crossroads/blocks/witchcraft/AbstractNutrientEnvironmentTileEntity.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/blocks/witchcraft/AbstractNutrientEnvironmentTileEntity.java
@@ -61,7 +61,9 @@ public abstract class AbstractNutrientEnvironmentTileEntity extends InventoryTE{
 	public void serverTick(){
 		super.serverTick();
 		long gameTime = level.getGameTime();
-		if(gameTime > lastTick && canCultivate()){
+		long timeSinceLastTick = gameTime - lastTick;
+
+		if(timeSinceLastTick > 0 && canCultivate()){
 			for(int cultivated : cultivatedSlots){
 				ItemStack stack = inventory[cultivated];
 				if(stack.getItem() instanceof ICultivatable item){
@@ -71,7 +73,7 @@ public abstract class AbstractNutrientEnvironmentTileEntity extends InventoryTE{
 						fluids[nutrientTankIndex].shrink(1);
 					}
 					//Update the item
-					item.cultivate(stack, level, 1);
+					item.cultivate(stack, level, timeSinceLastTick);
 				}
 			}
 		}
@@ -80,25 +82,6 @@ public abstract class AbstractNutrientEnvironmentTileEntity extends InventoryTE{
 	}
 
 	protected abstract int getPassiveNutrientDrainInterval();
-
-	@Override
-	public void onLoad(){
-		super.onLoad();
-		//While this block is unloaded, the gametime has still been advancing,
-		//so the stored items have decayed without this block countering that
-		//When we reload, we do a single large freeze operation to account for time spent unloaded, plus a small extra as a buffer
-		long gameTime = level.getGameTime();
-		if(gameTime > lastTick){
-			for(int cultivated : cultivatedSlots){
-				ItemStack stack = inventory[cultivated];
-				if(stack.getItem() instanceof ICultivatable){
-					((ICultivatable) stack.getItem()).cultivate(stack, level, gameTime - lastTick + 1);
-				}
-			}
-		}
-		lastTick = gameTime;
-//		setChanged(); Note to self: Calling setChanged() in onLoad() freezes the loading process; bad
-	}
 
 	@Override
 	public void loadAdditional(CompoundTag nbt, HolderLookup.Provider registries){

--- a/src/main/java/com/Da_Technomancer/crossroads/blocks/witchcraft/ColdStorageTileEntity.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/blocks/witchcraft/ColdStorageTileEntity.java
@@ -62,11 +62,13 @@ public class ColdStorageTileEntity extends InventoryTE implements IHeatCapable, 
 		double preTemp = temp;
 		double biomeTemp = getBiomeTemp();
 
+		long timeSinceLastTick = gameTime - lastTick;
+
 		for(ItemStack stack : inventory){
 			if(stack.getItem() instanceof IPerishable){
-				if(gameTime != lastTick){
+				if(timeSinceLastTick > 0){
 					//Don't allow tick accelerating this step, or the life span of the contents will actually increase
-					((IPerishable) stack.getItem()).freeze(stack, level, preTemp, 1);
+					((IPerishable) stack.getItem()).freeze(stack, level, preTemp, timeSinceLastTick);
 				}
 
 				if(temp < biomeTemp){
@@ -76,27 +78,6 @@ public class ColdStorageTileEntity extends InventoryTE implements IHeatCapable, 
 		}
 		lastTick = gameTime;
 		setChanged();
-	}
-	//Called whenever a BlockEntity is loaded
-	@Override
-	public void clearRemoved(){
-		super.clearRemoved();
-		//Server side only
-		if(!level.isClientSide()){
-			//While this block is unloaded, the gametime has still been advancing,
-			//so the stored items have decayed without this block countering that
-			//When we reload, we do a single large freeze operation to account for time spent unloaded, plus a small extra as a buffer
-			long gameTime = level.getGameTime();
-
-			if(gameTime > lastTick && lastTick != 0){
-				for(ItemStack stack : inventory){
-					if(stack.getItem() instanceof IPerishable perishable){
-						perishable.freeze(stack, level, temp, gameTime - lastTick + 5);
-					}
-				}
-			}
-			lastTick = gameTime;
-		}
 	}
 
 	@Override

--- a/src/main/java/com/Da_Technomancer/crossroads/blocks/witchcraft/StasisStorageTileEntity.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/blocks/witchcraft/StasisStorageTileEntity.java
@@ -48,39 +48,19 @@ public class StasisStorageTileEntity extends InventoryTE implements IBeamCapable
 
 		long gameTime = level.getGameTime();
 
-		if(gameTime != lastTick){
+		long timeSinceLastTick = gameTime - lastTick;
+
+		if(timeSinceLastTick > 0){
 			//Don't allow tick accelerating this step, or the life span of the contents will actually increase
 			for(ItemStack stack : inventory){
 				if(stack.getItem() instanceof IPerishable perishable){
 					//We reverse the age, without freezing, to prevent damage of ICultivatable
-					IPerishable.setSpoilTime(stack, IPerishable.getAndInitSpoilTime(stack, level) + 1, 0);
+					IPerishable.setSpoilTime(stack, IPerishable.getAndInitSpoilTime(stack, level) + timeSinceLastTick, 0);
 				}
 			}
 		}
 		lastTick = gameTime;
 		setChanged();
-	}
-
-	//Called whenever a TileEntity is loaded
-	@Override
-	public void clearRemoved(){
-		super.clearRemoved();
-		//Server side only
-		if(!level.isClientSide()){
-			//While this block is unloaded, the gametime has still been advancing,
-			//so the stored items have decayed without this block countering that
-			//When we reload, we do a single large freeze operation to account for time spent unloaded, plus a small extra as a buffer
-			long gameTime = level.getGameTime();
-
-			if(gameTime > lastTick && lastTick != 0){
-				for(ItemStack stack : inventory){
-					if(stack.getItem() instanceof IPerishable){
-						IPerishable.setSpoilTime(stack, IPerishable.getAndInitSpoilTime(stack, level) + gameTime - lastTick + 5, 0);
-					}
-				}
-			}
-			lastTick = gameTime;
-		}
 	}
 
 	@Override


### PR DESCRIPTION
Fixes #310 

Spawn chunks stay loaded even when not being actively ticked. Several block entities that tried to update spoil time values on a block being loaded failed within these chunks, because that block wouldn't "reload" when it started ticking again. Since spoil time is tracked as a time at which it will spoil, this resulted in the clock counting down while the player was not present in the chunk, regardless of whether the item should have been preserved.

Addressed this by making the server tick adjust spoil time outwards by the number of ticks since last update.

Spawn chunks remaining loaded will cease to be a problem in 1.21.9, though I don't see a reason to revert at that time.