### PR TITLE
Fix heat pipe connections on Fluid Cooling Chamber

### DIFF
--- a/src/main/java/com/Da_Technomancer/crossroads/blocks/heat/FluidCoolingChamberTileEntity.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/blocks/heat/FluidCoolingChamberTileEntity.java
@@ -166,7 +166,10 @@ public class FluidCoolingChamberTileEntity extends InventoryTE implements IHeatC
 	@Override
 	@Nullable
 	public IHeatHandler getHeatHandler(Direction direction){
-		return heatHandler;
+		if (direction.equals(Direction.UP)) {
+			return heatHandler;
+		}
+		return null;
 	}
 
 	@Override


### PR DESCRIPTION
As above.

This was dropped when I adapted the cooling chamber for the new capability fetching system in neoforge. 

There is no associated issue for this.