### PR TITLE
Fix item handler never being supplied on the Resonance Extractor

### DIFF
--- a/src/main/java/com/Da_Technomancer/crossroads/blocks/beams/BeamExtractorTileEntity.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/blocks/beams/BeamExtractorTileEntity.java
@@ -107,7 +107,7 @@ public class BeamExtractorTileEntity extends BeamRenderTE implements RecipeInput
 	@Nullable
 	@Override
 	public IItemHandler getItemHandler(Direction direction){
-		if(facing != getFacing()){
+		if(direction != getFacing()){
 			return itemHandler;
 		}
 		return null;


### PR DESCRIPTION
Fixes: Resonance Extractors weren't returning their `ItemHandler` because the direction condition they were checking on was never true. 