### PR TITLE
1.21: fix beacon harness not updating its beam correctly on the client

### DIFF
--- a/src/main/java/com/Da_Technomancer/crossroads/blocks/technomancy/BeaconHarnessTileEntity.java
+++ b/src/main/java/com/Da_Technomancer/crossroads/blocks/technomancy/BeaconHarnessTileEntity.java
@@ -252,6 +252,7 @@ public class BeaconHarnessTileEntity extends BeamRenderTE implements IFluxLink, 
 
 	@Override
 	public void receiveLong(byte identifier, long message, @Nullable ServerPlayer serverPlayerEntity){
+		super.receiveLong(identifier, message, serverPlayerEntity);
 		fluxHelper.receiveLong(identifier, message, serverPlayerEntity);
 	}
 


### PR DESCRIPTION
needs testing; the neoforge deve env is broken for me. Works on 1.20.